### PR TITLE
Support for up to 5 parameters on callFunc + getScene() implementation

### DIFF
--- a/test/brsTypes/components/RoSGNode.test.js
+++ b/test/brsTypes/components/RoSGNode.test.js
@@ -833,6 +833,7 @@ describe("RoSGNode", () => {
             child2 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("3") }]);
             child3 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("4") }]);
             child4 = new RoSGNode([{ name: new BrsString("child"), value: new BrsString("5") }]);
+            scene = new RoSGNode([{ name: new BrsString("Scene"), value: new BrsString("6") }]);
         });
 
         describe("getchildcount", () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -151,7 +151,7 @@ describe("end to end brightscript functions", () => {
             "callback 1 called",
             "callback 2 called",
             "field 3 updated",
-            //ifNodeChildren tests
+            //ifSGNodeChildren tests
             "parent child count: ",
             "0",
             "get same parent from child: ",
@@ -228,6 +228,10 @@ describe("end to end brightscript functions", () => {
             "false",
             "Node subtype is returned:",
             "Node",
+            "Node root scene is returned:",
+            "invalid",
+            "Node root scene name is returned:",
+            "Scene",
             "updatedId",
             "invalid",
             "updatedId",
@@ -627,6 +631,12 @@ describe("end to end brightscript functions", () => {
             "invalid",
             "main: componentPrivateFunction return value:",
             "invalid",
+            "component: inside componentFunctionMultipleParams, args.test: ",
+            "123",
+            "component: inside componentFunctionMultipleParams, args2.test: ",
+            "456",
+            "main: componentFunctionMultipleParams return value success:",
+            "true",
         ]);
 
         expect(allArgs(outputStreams.stderr.write).filter((arg) => arg !== "\n")).toEqual([

--- a/test/e2e/ComponentTop.test.js
+++ b/test/e2e/ComponentTop.test.js
@@ -30,6 +30,8 @@ describe("m.top usage in scenegraph components", () => {
             "false",
             "300",
             "100",
+            "invalid",
+            "scene",
             "this value set using m.top",
             "invalid",
         ]);

--- a/test/e2e/resources/components/CallFuncComponent.xml
+++ b/test/e2e/resources/components/CallFuncComponent.xml
@@ -4,5 +4,6 @@
     <interface>
         <function name="componentFunction" />
         <function name="componentVoidFunction" />
+        <function name="componentFunctionMultipleParams" />
     </interface>
 </component>

--- a/test/e2e/resources/components/roSGNode.brs
+++ b/test/e2e/resources/components/roSGNode.brs
@@ -185,6 +185,16 @@ sub main()
     ' returns the node subtype
     print "Node subtype is returned:" n.subtype()                       ' => Node
 
+    ' returns the invalid node scene
+    print "Node root scene is returned:" n.getScene()                       ' => Invalid
+    
+    sceneNode = createObject("roSGNode", "Node")
+    sceneNode.id = "scene"
+    sceneNode.name = "Scene"
+    _brs_.global.scene = sceneNode
+    ' returns node scene with id "scene"
+    print "Node root scene name is returned:" n.getScene().name                       ' => Scene
+
     ' calling update function without optional createFields parameter doesn't add new fields
     node = createObject("roSGNode", "Node")
     node.id = "originalId"

--- a/test/e2e/resources/components/scripts/CallFuncComponent.brs
+++ b/test/e2e/resources/components/scripts/CallFuncComponent.brs
@@ -18,3 +18,18 @@ function componentPrivateFunction() as string
     print "component: inside componentPrivateFunction"
     return "private return value"
 end function
+
+function componentFunctionMultipleParams(args as object, args2 as object) as object
+    print "component: inside componentFunctionMultipleParams, args.test: " args.test
+    print "component: inside componentFunctionMultipleParams, args2.test: " args2.test
+
+    argsCount = 0
+    if args <> invalid
+        argsCount += 1
+    end if
+
+    if args2 <> invalid
+        argsCount += 1
+    end if
+    return { "success": argsCount = 2 }
+end function

--- a/test/e2e/resources/components/scripts/CallFuncMain.brs
+++ b/test/e2e/resources/components/scripts/CallFuncMain.brs
@@ -12,4 +12,8 @@ sub Main()
 
     privateResult = node.callFunc("componentPrivateFunction")
     print "main: componentPrivateFunction return value:" privateResult ' => invalid
+
+    result = node.callFunc("componentFunctionMultipleParams", { test: 123 }, { test: 456 })
+    print "main: componentFunctionMultipleParams return value success:" result.success ' => true
+
 end sub

--- a/test/e2e/resources/components/scripts/MTopWidget.brs
+++ b/test/e2e/resources/components/scripts/MTopWidget.brs
@@ -10,6 +10,17 @@ sub init()
     childRect = m.top.findNode("childRectangle")
     print childRect.width
     print childRect.height
+
+
+    print m.top.getScene() ' => invalid
+
+    sceneNode = CreateObject("roSGNode", "Node")
+    sceneNode.id = "scene"
+    m.global.addFields({
+        scene: sceneNode
+    })
+
+    print m.top.getScene().id ' => scene
 end sub
 
 function getDefaultTopValue() as string


### PR DESCRIPTION
- `callFunc` now accepts up to 5 arguments
- You can now set a node through `_brs_.global.scene = node` and it can be accessible through any node `m.top.getScene()` function
- Added `observeFieldScoped` as a shortcut to `observeField`